### PR TITLE
Adds stdlib.debug_mute

### DIFF
--- a/lib/resources/apt.sh
+++ b/lib/resources/apt.sh
@@ -75,7 +75,7 @@ function stdlib.apt.read {
   fi
 
   # check to see if it's installed at all
-  stdlib.mute dpkg -s ${options[package]}
+  stdlib.debug_mute dpkg -s ${options[package]}
   if [[ $? == 1 ]]; then
     stdlib_current_state="absent"
     return

--- a/lib/resources/file_line.sh
+++ b/lib/resources/file_line.sh
@@ -61,14 +61,14 @@ function stdlib.file_line.read {
     return
   fi
 
-  stdlib.mute "grep -qx -- '${options[line]}' '${options[file]}'"
+  stdlib.debug_mute "grep -qx -- '${options[line]}' '${options[file]}'"
   if [[ $? == 1 ]]; then
     stdlib_current_state="absent"
     return
   fi
 
   if [[ -n ${options[match]} ]]; then
-    stdlib.mute "sed -n -e '/${options[match]}/p' '${options[file]}'"
+    stdlib.debug_mute "sed -n -e '/${options[match]}/p' '${options[file]}'"
     if [[ $? == 1 ]]; then
       stdlib.error "No match for ${options[match]} in ${options[file]}"
       if [[ $WAFFLES_EXIT_ON_ERROR == true ]]; then

--- a/lib/resources/sysvinit.sh
+++ b/lib/resources/sysvinit.sh
@@ -53,7 +53,7 @@ function stdlib.sysvinit.read {
       return 1
     fi
   else
-    stdlib.mute /etc/init.d/${options[name]} status
+    stdlib.debug_mute /etc/init.d/${options[name]} status
     if [[ $? != 0 ]]; then
       stdlib_current_state="stopped"
       return

--- a/lib/system.sh
+++ b/lib/system.sh
@@ -67,11 +67,24 @@ function stdlib.subtitle {
 
 
 # stdlib.mute turns off command output
+# and prints the command being run.
 function stdlib.mute {
   if stdlib.noop? ; then
     stdlib.info "(noop) $@"
   else
     stdlib.info "Running \"$@\""
+    eval $@ &>/dev/null
+    return $?
+  fi
+}
+
+# stdlib.debug_mute turns off command output
+# and prints the command being run at debug level
+function stdlib.debug_mute {
+  if stdlib.noop? ; then
+    stdlib.debug "(noop) $@"
+  else
+    stdlib.debug "Running \"$@\""
     eval $@ &>/dev/null
     return $?
   fi


### PR DESCRIPTION
This commit adds a stdlib.debug_mute function that will print the command
being run, but not the output of the command, when Waffles is run in Debug
mode. The reason for this function is because there are times when it makes
sense to use stdlib.mute in non-debug mode.

Fixes #8 
