### PR TITLE
Fix state check of a PPA resource.

### DIFF
--- a/lib/resources/apt_ppa.sh
+++ b/lib/resources/apt_ppa.sh
@@ -44,7 +44,7 @@ function stdlib.apt_ppa {
 
 function stdlib.apt_ppa.read {
   local _repo_file_name="$(echo ${options[ppa]} | sed -e "s|[/:]|-|" -e "s|\.|_|")-*.list"
-  if [ -f "/etc/apt/sources.list.d/$_repo_file_name" ]; then
+  if [ -f /etc/apt/sources.list.d/$_repo_file_name ]; then
     stdlib_current_state="present"
     return
   fi


### PR DESCRIPTION
Quoting perform a literal match and avoid interpretation of pattern metacharacters within the variable.
with quotes the file existence test always fail causing the resource to be reinstalled.
