### PR TITLE
profile_path

### DIFF
--- a/lib/stdlib/system.sh
+++ b/lib/stdlib/system.sh
@@ -182,11 +182,13 @@ function stdlib.profile {
       _profile="host_files/$_host"
     fi
 
-    if [[ -f "$WAFFLES_SITE_DIR/profiles/$_profile/scripts/${_file}.sh" ]]; then
-      _script_path="$WAFFLES_SITE_DIR/profiles/$_profile/scripts/${_file}.sh"
-    elif [[ -f "$WAFFLES_SITE_DIR/profiles/$_profile/scripts/init.sh" ]]; then
-      _script_path="$WAFFLES_SITE_DIR/profiles/$_profile/scripts/init.sh"
-    elif [[ ! -d "$WAFFLES_SITE_DIR/profiles/$_profile" ]]; then
+    profile_path="$WAFFLES_SITE_DIR/profiles/$_profile"
+
+    if [[ -f "$profile_path/scripts/${_file}.sh" ]]; then
+      _script_path="$profile_path/scripts/${_file}.sh"
+    elif [[ -f "$profile_path/scripts/init.sh" ]]; then
+      _script_path="$profile_path/scripts/init.sh"
+    elif [[ ! -d "$profile_path" ]]; then
       _profile=""
     fi
 


### PR DESCRIPTION
This commit adds the `$profile_path` variable which is a shortcut to the path
of the profile currently executing. This is useful when referencing source
files.
