### PR TITLE
Template Support

### DIFF
--- a/docs/functions/template.md
+++ b/docs/functions/template.md
@@ -1,0 +1,36 @@
+# Template Functions
+
+[TOC]
+
+`lib/stdlib/template.sh` contains functions related to templating.
+
+## stdlib.render_template
+
+`stdlib.render_template` requires the following two options:
+
+* `--template`: The path to the template file.
+* `--variables`: The name of a Bash associative array / hash that contains the variables to interpolate.
+
+`stdlib.render_template` will then echo the rendered template.
+
+### Example ###
+
+```shell
+$ cat profiles/test/files/test.tpl
+
+Hello, {{ name }}!
+Foo: {{ foo }}
+Bar: {{ bar }}
+
+$ cat profiles/test/data.sh
+
+declare -Ag data_template_vars=()
+data_template_vars[name]="Joe"
+data_template_vars[foo]="foobar"
+data_template_vars[bar]="barfoo"
+
+$ cat profiles/test/scripts/template_test.sh
+
+output=$(stdlib.render_template --template "$profile_files/test.tpl" --variables data_template_vars)
+stdlib.file --name /tmp/rendered.txt --contents "$output"
+```

--- a/docs/tools/mkdocs.yml.base
+++ b/docs/tools/mkdocs.yml.base
@@ -21,6 +21,7 @@ pages:
     - 'catalog': 'functions/catalog.md'
     - 'options': 'functions/options.md'
     - 'resource': 'functions/resource.md'
+    - 'template': 'functions/template.md'
     - 'augeas': 'functions/augeas.md'
     - 'consul': 'functions/consul.md'
     - 'mysql': 'functions/mysql.md'

--- a/lib/init.sh
+++ b/lib/init.sh
@@ -3,6 +3,7 @@ source "$WAFFLES_DIR/lib/stdlib/catalog.sh"
 source "$WAFFLES_DIR/lib/stdlib/options.sh"
 source "$WAFFLES_DIR/lib/stdlib/resource.sh"
 source "$WAFFLES_DIR/lib/stdlib/system.sh"
+source "$WAFFLES_DIR/lib/stdlib/template.sh"
 
 # Standard Library of Resources
 source "$WAFFLES_DIR/lib/stdlib/resources/apt.sh"

--- a/lib/stdlib/resources/file.sh
+++ b/lib/stdlib/resources/file.sh
@@ -124,11 +124,17 @@ function stdlib.file.create {
     stdlib.capture_error chown ${options[owner]}:${options[group]} "${options[name]}"
   else
     if [[ -n ${options[content]} ]]; then
-      local _script
-      read -r -d '' _script<<EOF
-echo '${options[content]}' > "${options[name]}"
-EOF
-      stdlib.capture_error "$_script"
+      echo "${options[content]}" > "${options[name]}"
+      _ret="$?"
+      if [[ $_ret != 0 ]]; then
+        stdlib.error "Errors occurred writing content to file."
+        if [[ $WAFFLES_EXIT_ON_ERROR == "true" ]]; then
+          stdlib.error "Halting run."
+          exit 1
+        else
+          return $_ret
+        fi
+      fi
     else
       stdlib.capture_error touch "${options[name]}"
     fi
@@ -152,12 +158,19 @@ function stdlib.file.update {
 
   if [[ -n $_md5 && $md5 != $_md5 ]]; then
     if [[ -n ${options[content]} ]]; then
-      local _script
-      read -r -d '' _script<<EOF
-echo '${options[content]}' > "${options[name]}"
-EOF
-      stdlib.capture_error "$_script"
+      echo "${options[content]}" > "${options[name]}"
+      _ret="$?"
+      if [[ $_ret != 0 ]]; then
+        stdlib.error "Errors occurred writing content to file."
+        if [[ $WAFFLES_EXIT_ON_ERROR == "true" ]]; then
+          stdlib.error "Halting run."
+          exit 1
+        else
+          return $_ret
+        fi
+      fi
     fi
+
     if [[ -n ${options[source]} ]]; then
       stdlib.capture_error cp "${options[source]}" "${options[name]}"
     fi

--- a/lib/stdlib/template.sh
+++ b/lib/stdlib/template.sh
@@ -1,0 +1,17 @@
+function stdlib.render_template {
+  local -A options
+  stdlib.options.create_option template    "__required__"
+  stdlib.options.create_option variables   "__required__"
+  stdlib.options.parse_options "$@"
+
+  local -n _variables="${options[variables]}"
+
+  _template=$(<"${options[template]}")
+
+  for _key in "${!_variables[@]}"; do
+    _value="${_variables[$_key]}"
+    _template="${_template//\{\{ $_key \}\}/$_value}"
+  done
+
+  echo "$_template"
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ pages:
     - 'catalog': 'functions/catalog.md'
     - 'options': 'functions/options.md'
     - 'resource': 'functions/resource.md'
+    - 'template': 'functions/template.md'
     - 'augeas': 'functions/augeas.md'
     - 'consul': 'functions/consul.md'
     - 'mysql': 'functions/mysql.md'


### PR DESCRIPTION
This commit introduces basic templating support into Waffles.

The function `stdlib.render_template` takes a template file and
and an associative array / hash of variable as input. It then echoes
the rendered template which can be used as the contents of a file.

Only interpolation of `{{ varname }}` strings are supported at this time.
