### PR TITLE
Redirect all output to standard error

### DIFF
--- a/lib/stdlib/system.sh
+++ b/lib/stdlib/system.sh
@@ -29,11 +29,11 @@ function stdlib.debug {
 }
 
 function stdlib.info {
-  echo -e "${stdlib_color_green}(info)  ${stdlib_title}${stdlib_subtitle}${stdlib_color_reset}${@}"
+  echo -e "${stdlib_color_green}(info)  ${stdlib_title}${stdlib_subtitle}${stdlib_color_reset}${@}" >&2
 }
 
 function stdlib.warn {
-  echo -e "${stdlib_color_yellow}(warn)  ${stdlib_title}${stdlib_subtitle}${stdlib_color_reset}${@}"
+  echo -e "${stdlib_color_yellow}(warn)  ${stdlib_title}${stdlib_subtitle}${stdlib_color_reset}${@}" >&2
 }
 
 function stdlib.error {


### PR DESCRIPTION
In my opinion, all status messages should go to standard error, leaving standard output for information other scripts would consume.  At any rate, it seems inconsistent having `stdlib.debug` and `stdlib.error` output to stderr but `stdlib.info` and `stdlib.warning` to stdout.  Nevertheless, I am no expert; what do you think?
