### PR TITLE
Updating Test Kitchen Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,24 +58,14 @@ certain functions work correctly.
 
 Acceptance tests are used to verify resources work correctly.
 [Test Kitchen](http://kitchen.ci/) and Docker are used to run the suite of
-tests. You can create a testing environment by roughly doing:
+tests. Use the [install.sh](https://github.com/wffls/waffles/blob/master/tests/kitchen/install.sh)
+Waffles script to set up Test Kitchen and all other requirements on an
+Ubuntu-based system.
+
+Then execute test suites by doing:
 
 ```bash
-apt-get update
-apt-get install -y ruby
-wget -qO- https://get.docker.com/
-gem install test-kitchen
-gem install kitchen-docker
-gem install busser-bash
-gem install busser-bats
-gem install busser-serverspec
-kitchen init --driver=kitchen-docker
-```
-
-Then execute test suites by:
-
-```bash
-$ cd tests/kitchen
+$ cd /root/.waffles/tests/kitchen
 $ kitchen test ubuntu1404-ubuntu-1404
 ```
 

--- a/tests/kitchen/install.sh
+++ b/tests/kitchen/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+source /opt/waffles/init.sh
+source /etc/lsb-release
+
+apt.pkg --name git
+apt.pkg --name ruby2.0
+os.symlink --name /usr/bin/ruby --target /usr/bin/ruby2.0 --overwrite true
+os.symlink --name /usr/bin/gem --target /usr/bin/gem2.0 --overwrite true
+
+apt.key --name docker --key 58118E89F3A912897C070ADBF76221572C52609D --keyserver hkp://p80.pool.sks-keyservers.net:80
+apt.source --name docker --uri https://apt.dockerproject.org/repo --distribution ubuntu-$DISTRIB_CODENAME --component main
+apt.pkg --name docker-engine
+
+ruby.gem --name test-kitchen
+ruby.gem --name kitchen-docker
+ruby.gem --name busser-bash
+ruby.gem --name busser-bats
+ruby.gem --name busser-serverspec
+
+git.repo --name /root/.waffles --source https://github.com/wffls/waffles


### PR DESCRIPTION
This commit updates the installation instructions about how to install
and setup Test Kitchen as well as provides a Waffles script to do all
of the work.

Fixes #181 
