### PR TITLE
apt_ppa.sh documentation fix

### DIFF
--- a/resources/apt_ppa.sh
+++ b/resources/apt_ppa.sh
@@ -15,7 +15,7 @@
 # === Example
 #
 # ```bash
-# apt.ppa --ppa ppa:chris-lea/redis-server
+# apt.ppa --ppa chris-lea/redis-server
 # ```
 #
 apt.ppa() {


### PR DESCRIPTION
Should not include ppa: in the example.
